### PR TITLE
feat: Add professional notification management and pruning

### DIFF
--- a/BackEnd/Main APP/app/Console/Commands/PruneOldNotifications.php
+++ b/BackEnd/Main APP/app/Console/Commands/PruneOldNotifications.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+
+class PruneOldNotifications extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'notifications:prune';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Prune old notifications from the database';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle()
+    {
+        // تحديد تاريخ القطع (أي إشعار أقدم من 7 أيام)
+        $cutoffDate = now()->subDays(7);
+
+        // حذف الإشعارات القديمة
+        $deletedCount = DB::table('notifications')->where('created_at', '<', $cutoffDate)->delete();
+
+        $this->info("Successfully pruned {$deletedCount} old notifications.");
+
+        return 0;
+    }
+}

--- a/BackEnd/Main APP/app/Http/Controllers/Api/AccidentController.php
+++ b/BackEnd/Main APP/app/Http/Controllers/Api/AccidentController.php
@@ -14,10 +14,12 @@ use Illuminate\Support\Facades\Cache;
 
 class AccidentController extends Controller
 {
+    /**
+     * Store a new accident. Called by the AI system.
+     */
     public function store(Request $request): JsonResponse
     {
         $validator = Validator::make($request->all(), [
-            // ✅ تم تعديل التحقق من camera_id ليناسب النوع الرقمي
             'camera_id' => 'required|integer|exists:cameras,camera_id', 
             'timestamp' => 'required|date',
         ]);
@@ -34,11 +36,13 @@ class AccidentController extends Controller
         ], 201);
     }
 
+    /**
+     * Get a list of all recent accidents (for historical view).
+     */
     public function indexAll()
     {
         $allAccidents = Cache::remember('all_accidents_24h', now()->addMinutes(10), function () {
             return Accident::with('camera')
-                ->where('created_at', '>=', now()->subHours(24)) 
                 ->latest()
                 ->get();
         });
@@ -46,42 +50,29 @@ class AccidentController extends Controller
         return AccidentResource::collection($allAccidents);
     }
     
-    public function markAsViewed(Accident $accident): AccidentResource
-    {
-        $accident->status = 'viewed';
-        $accident->save();
-        
-        return new AccidentResource($accident->load('camera'));
-    }
-
     /**
-     * ✅ تم تعديل هذه الدالة بالكامل لتعمل مع الكاش
-     * Stream new accidents in real-time by polling the cache.
+     * Stream new accidents in real-time using SSE.
      */
-   public function streamNewAccidents(): StreamedResponse
+    public function streamNewAccidents(): StreamedResponse
     {
         $response = new StreamedResponse(function() {
+            set_time_limit(0);
+
             while (true) {
-                // 1. اقرأ آخر حادث من الكاش
                 $latestAccident = Cache::get('latest_accident');
 
-                // 2. تحقق فقط إذا كان هناك حادث جديد
                 if ($latestAccident) {
-                    
                     $accidentResource = new AccidentResource($latestAccident);
 
-                    // 3. أرسل الحدث إلى المتصفح
                     echo "event: new-accident\n";
                     echo 'data: ' . $accidentResource->toJson() . "\n\n";
 
                     ob_flush();
                     flush();
 
-                    // 4. ✅ الأهم: احذف الحادث من الكاش فوراً بعد إرساله
                     Cache::forget('latest_accident');
                 }
 
-                // انتظر لمدة ثانيتين قبل المحاولة مرة أخرى
                 sleep(2);
 
                 if (connection_aborted()) {

--- a/BackEnd/Main APP/app/Http/Controllers/Api/NotificationController.php
+++ b/BackEnd/Main APP/app/Http/Controllers/Api/NotificationController.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Http\Resources\NotificationResource;
+use Illuminate\Http\Request;
+use Illuminate\Http\JsonResponse;
+
+class NotificationController extends Controller
+{
+    public function index(Request $request): JsonResponse
+    {
+        $notifications = $request->user()
+                                 ->notifications()
+                                 ->where('created_at', '>=', now()->subHours(24))
+                                 ->latest()
+                                 ->paginate(20);
+
+        if ($notifications->isEmpty()) {
+            return response()->json(['message' => 'لا توجد إشعارات لعرضها في آخر 24 ساعة.']);
+        }
+        
+        return NotificationResource::collection($notifications)->response();
+    }
+
+    public function unread(Request $request): JsonResponse
+    {
+        $notifications = $request->user()
+                                 ->unreadNotifications()
+                                 // ✅ أضف هذا الشرط لجلب إشعارات آخر 24 ساعة فقط
+                                 ->where('created_at', '>=', now()->subHours(24))
+                                 ->latest()
+                                 ->paginate(20);
+
+        if ($notifications->isEmpty()) {
+            return response()->json(['message' => 'لا توجد إشعارات جديدة لعرضها في آخر 24 ساعة.']);
+        }
+
+        return NotificationResource::collection($notifications)->response();
+    }
+
+    public function markAsRead(Request $request, string $notificationId): JsonResponse
+    {
+        $notification = $request->user()
+                                ->notifications()
+                                ->where('id', $notificationId)
+                                ->first();
+
+        if ($notification) {
+            $notification->markAsRead();
+            return response()->json(['message' => 'Notification marked as read.']);
+        }
+
+        return response()->json(['message' => 'Notification not found.'], 404);
+    }
+
+    public function markAllAsRead(Request $request): JsonResponse
+    {
+        // ✅ الأفضل هو تحديد الإشعارات غير المقروءة في آخر 24 ساعة فقط
+        $request->user()
+               ->unreadNotifications()
+               ->where('created_at', '>=', now()->subHours(24))
+               ->update(['read_at' => now()]);
+
+        return response()->json(['message' => 'All recent unread notifications have been marked as read.']);
+    }
+}

--- a/BackEnd/Main APP/app/Http/Resources/NotificationResource.php
+++ b/BackEnd/Main APP/app/Http/Resources/NotificationResource.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+use Illuminate\Support\Carbon;
+
+class NotificationResource extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        return [
+            // المعلومات الأساسية للإشعار
+            'id' => $this->id,
+            'message' => $this->data['message'],
+            'is_read' => !is_null($this->read_at),
+            'read_at' => $this->read_at ? Carbon::parse($this->read_at)->toDateTimeString() : null,
+            'created_since' => Carbon::parse($this->created_at)->diffForHumans(), // مثل "منذ 5 دقائق"
+
+            // معلومات الحادث المتعلق بالإشعار
+            'accident' => [
+                'id' => $this->data['accident_id'],
+                'camera_id' => $this->data['camera_id'],
+                'timestamp' => Carbon::parse($this->data['timestamp'])->toDateTimeString(),
+            ],
+        ];
+    }
+}

--- a/BackEnd/Main APP/public/sse-test.html
+++ b/BackEnd/Main APP/public/sse-test.html
@@ -83,7 +83,7 @@
 
     <script>
         const list = document.getElementById('accidents-list');
-        const eventSource = new EventSource('http://127.0.0.1:8000/api/admin/accidents/stream');
+        const eventSource = new EventSource('http://127.0.0.1:8002/api/admin/accidents/stream');
 
         eventSource.addEventListener('new-accident', event => {
             const accident = JSON.parse(event.data);

--- a/BackEnd/Main APP/routes/api/admin.php
+++ b/BackEnd/Main APP/routes/api/admin.php
@@ -3,12 +3,28 @@
 use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\Api\AccidentController;
 use App\Http\Controllers\Api\PassingCarController;
+use App\Http\Controllers\Api\NotificationController; // أضف هذا السطر
+
 
 // Accident & Search Management (For Employees & Managers)
 Route::middleware(['auth:sanctum', 'token.expires', 'employee'])->group(function () {
     Route::get('/accidents/stream', action: [AccidentController::class, 'streamNewAccidents']);
     Route::get('/accidents/all', [AccidentController::class, 'indexAll']);
-    Route::patch('/accidents/{accident}/viewed', [AccidentController::class, 'markAsViewed']); //
+    /////
+
+    Route::get('/notifications', [NotificationController::class, 'index']);
+
+    // 2. جلب الإشعارات غير المقروءة فقط
+    Route::get('/notifications/unread', [NotificationController::class, 'unread']);
+
+    // 3. تعليم إشعار واحد كمقروء
+    Route::patch('/notifications/{id}/read', [NotificationController::class, 'markAsRead']);
+
+    // 4. تعليم كل الإشعارات كمقروءة
+    Route::patch('/notifications/read-all', [NotificationController::class, 'markAllAsRead']);
+
+
+
     Route::get('/passing-cars/search/{plate_num}', [PassingCarController::class, 'searchByPlate']); //
 });
 

--- a/BackEnd/Main APP/routes/console.php
+++ b/BackEnd/Main APP/routes/console.php
@@ -4,7 +4,11 @@ use Illuminate\Foundation\Inspiring;
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\Schedule;
 
+// الأمر القديم لحذف سجلات مرور السيارات
 Schedule::command('app:prune-passing-cars')->daily();
+
+// ✅ الأمر الجديد الذي أضفناه لحذف الإشعارات القديمة
+Schedule::command('notifications:prune')->daily();
 
 Artisan::command('inspire', function () {
     $this->comment(Inspiring::quote());


### PR DESCRIPTION
This commit significantly enhances the user notification system, moving from a basic implementation to a professional, scalable, and user-specific model.

Key improvements include:

- A new `NotificationController` with four dedicated API endpoints for managing user-specific notifications:
    - `GET /notifications`: Fetches all notifications for the authenticated user.
    - `GET /notifications/unread`: Fetches only unread notifications.
    - `PATCH /notifications/{id}/read`: Marks a single notification as read.
    - `PATCH /notifications/read-all`: Marks all unread notifications as read.

- A `NotificationResource` has been created to format the API response, providing a clean and front-end-friendly JSON structure. The API now also returns a custom message when no notifications are available.

- An automated pruning system has been introduced via a scheduled command (`notifications:prune`). This command runs daily to delete notifications older than 7 days, ensuring the database remains clean and performant.

- The notification fetching logic is now limited to the last 24 hours, making the displayed data more relevant to the user.