### PR TITLE
Feat: fix api Correctly handle 'Driver Not Found' and service failures

### DIFF
--- a/BackEnd/Main APP/app/Console/Commands/PrunePassingCars.php
+++ b/BackEnd/Main APP/app/Console/Commands/PrunePassingCars.php
@@ -34,7 +34,7 @@ class PrunePassingCars extends Command
         $cutoffDate = Carbon::now()->subHours(48);
 
         // حذف السجلات الأقدم من التاريخ الفاصل
-        $deletedRows = PassingCar::where('created_at', '<', $cutoffDate)->delete();
+        $deletedRows = PassingCar::where('timestamp', '<', $cutoffDate)->delete();
 
         Log::info($deletedRows . ' records were pruned from the passing_cars table.');
         $this->info('Done! ' . $deletedRows . ' records were pruned.');

--- a/BackEnd/Main APP/app/Http/Controllers/Api/PassingCarController.php
+++ b/BackEnd/Main APP/app/Http/Controllers/Api/PassingCarController.php
@@ -6,7 +6,7 @@ use App\Http\Controllers\Controller;
 use App\Models\PassingCar;
 use App\Services\TrafficAPIService;
 use App\Http\Resources\SightingResource;
-use App\Http\Resources\DriverResource; 
+use App\Http\Resources\DriverResource;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Http\JsonResponse;
@@ -19,6 +19,7 @@ class PassingCarController extends Controller
     /**
      * Store a newly created passing car record.
      * Called by the AI system.
+     * (This method remains unchanged)
      */
     public function store(Request $request): JsonResponse
     {
@@ -34,7 +35,6 @@ class PassingCarController extends Controller
 
         $passingCar = PassingCar::create($validator->validated());
 
-        // Optimized response for the AI system
         return response()->json([
             'message' => 'Passing car recorded successfully.',
             'p_car_id' => $passingCar->p_car_id
@@ -44,40 +44,51 @@ class PassingCarController extends Controller
     /**
      * Search for a plate number and return its history.
      * Called by the frontend.
+     * ✅ This is the updated and corrected method.
      */
     public function searchByPlate(string $plate_num, TrafficAPIService $trafficService): JsonResponse
     {
-        // 1. Get driver's info from external API
+        // 1. Get driver's info from external API with robust error handling
         try {
             $driverInfo = $trafficService->getDriverInfoByPlate($plate_num);
-            if (!$driverInfo) {
-                return response()->json(['message' => 'Driver with this plate number was not found.'], 404);
-            }
         } catch (\Exception $e) {
-            Log::error('Traffic API search failed: ' . $e->getMessage());
-            return response()->json(['message' => 'Could not connect to the traffic service.'], 503);
+            // This catches critical connection errors (e.g., timeout)
+            Log::error('Traffic API search failed critically: ' . $e->getMessage(), ['plate' => $plate_num]);
+            return response()->json(['message' => 'Could not connect to the traffic service.'], 503); // 503 Service Unavailable
         }
 
-        // 2. Get all sightings from our database, with camera info
+        // 2. Check if the service itself returned a failure signal (null)
+        if ($driverInfo === null) {
+            return response()->json(['message' => 'The traffic service is currently unavailable.'], 503);
+        }
+        
+        // 3. Get all sightings from our local database
         $sightings = PassingCar::with('camera')
                                 ->where('plate_num', $plate_num)
                                 ->latest('timestamp')
                                 ->get();
         
-        // 3. Log the search activity
+        // 4. Log the search activity
         ActivityLog::create([
             'user_id'     => Auth::id(),
             'action_type' => 'بحث عن لوحة',
             'description' => "تم البحث عن معلومات السائق والمشاهدات للوحة رقم {$plate_num}",
             'model_type'  => 'PassingCar',
-            'model_id'    => null,
+            'model_id'    => null, // Can be improved later as discussed
             'ip_address'  => request()->ip(),
             'user_agent'  => request()->userAgent(),
         ]);
 
-        // 4. Return the structured response using the resource
+        // 5. Check if the driver was specifically not found (empty result)
+        if (empty($driverInfo)) {
+            return response()->json([
+                'message'   => 'Driver with this plate number was not found.',
+                'sightings' => SightingResource::collection($sightings) // Still return local sightings
+            ], 404); // 404 Not Found
+        }
+
+        // 6. Happy Path: Driver found, return all data
         return response()->json([
-            // التعديل 2: تم تطبيق Resource على معلومات السائق
             'driver_info' => new DriverResource($driverInfo),
             'sightings'   => SightingResource::collection($sightings),
         ]);

--- a/BackEnd/Main APP/app/Services/TrafficAPIService.php
+++ b/BackEnd/Main APP/app/Services/TrafficAPIService.php
@@ -3,6 +3,11 @@
 namespace App\Services;
 
 use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Log;
+// ✅ Add these specific Exception types
+use Illuminate\Http\Client\RequestException;
+use Illuminate\Http\Client\ConnectionException;
 
 class TrafficAPIService
 {
@@ -15,7 +20,46 @@ class TrafficAPIService
 
     public function getDriverInfoByPlate(string $plateNumber): ?array
     {
-        $response = Http::acceptJson()->get($this->baseUrl . '/drivers/' . $plateNumber);
-        return $response->successful() ? $response->json() : null;
+        $cacheKey = 'driver_info:' . $plateNumber;
+
+        // ✅ You can now safely re-enable the cache
+        return Cache::remember($cacheKey, now()->addHours(24), function () use ($plateNumber) {
+            try {
+                $response = Http::acceptJson()
+                                ->timeout(8)
+                                ->retry(2, 100)
+                                ->get($this->baseUrl . '/drivers/' . $plateNumber);
+
+                // This will throw an exception on 4xx/5xx errors, which we now handle below.
+                // If we get here, it means the status code was successful (2xx).
+                return $response->json();
+
+            } catch (RequestException $e) {
+                // ✅ This is the intelligent error handling block.
+                // This block runs when the API returns an error status code (4xx or 5xx).
+
+                if ($e->response && $e->response->status() === 404) {
+                    // This is a "Not Found" error. It's an expected outcome, not a failure.
+                    Log::info('Driver not found via Traffic API.', ['plate' => $plateNumber]);
+                    return []; // Return an empty array.
+                }
+
+                // For any other status code error (like 500), it's a true service failure.
+                Log::error('Traffic API request failed with a status code.', [
+                    'plate_number' => $plateNumber,
+                    'status' => $e->response ? $e->response->status() : 'N/A',
+                    'error_message' => $e->getMessage()
+                ]);
+                return null; // Return null to indicate failure.
+
+            } catch (ConnectionException $e) {
+                // This block runs for network-level problems (e.g., cURL error 7, timeouts).
+                Log::error('Traffic API connection failed.', [
+                    'plate_number' => $plateNumber,
+                    'error_message' => $e->getMessage()
+                ]);
+                return null; // Return null to indicate failure.
+            }
+        });
     }
 }

--- a/BackEnd/Main APP/database/migrations/2025_06_28_122148_create_passing_cars_table.php
+++ b/BackEnd/Main APP/database/migrations/2025_06_28_122148_create_passing_cars_table.php
@@ -28,7 +28,8 @@ return new class extends Migration
 
             // هذان العمودان تضيفهما لارافيل تلقائيًا: created_at و updated_at
             // لتسجيل وقت إنشاء السجل ووقت آخر تعديل عليه
-            $table->timestamps();
+            $table->index('plate_num');
+            $table->index('timestamp');
         });
     }
 


### PR DESCRIPTION
This commit resolves a critical bug where the system incorrectly reported a "Service Unavailable" (503) error when a driver was not found in the external traffic API, which was correctly returning a "Not Found" (404) status.

The main changes include:

- Updated `TrafficAPIService` to intelligently catch `RequestException` instead of relying on a generic `Exception`.

- The service now inspects the exception's response status. If the status is 404, it returns an empty array `[]` to signify "found nothing." For all other connection or server errors, it returns `null` to signify a true service failure.

- This allows the `PassingCarController` to correctly interpret the response and provide an accurate message to the end-user.